### PR TITLE
Adding link to Dict docs

### DIFF
--- a/interop/json.md
+++ b/interop/json.md
@@ -80,7 +80,7 @@ So now we can handle JSON arrays. If we want to get extra crazy, we can even nes
 Ok [[0],[1,2,3],[4,5]] : Result String (List (List Int))
 ```
 
-So that is `list`, but `Json.Decode` can handle many other data structures too. For example, [`dict`](http://package.elm-lang.org/packages/elm-lang/core/latest/Json-Decode#dict) helps you turn a JSON object into an Elm `Dict` and [`keyValuePairs`](http://package.elm-lang.org/packages/elm-lang/core/latest/Json-Decode#keyValuePairs) helps you turn a JSON object into an Elm list of keys and values.
+So that is `list`, but `Json.Decode` can handle many other data structures too. For example, [`dict`](http://package.elm-lang.org/packages/elm-lang/core/latest/Json-Decode#dict) helps you turn a JSON object into an Elm [`Dict`](http://package.elm-lang.org/packages/elm-lang/core/latest/Dict) and [`keyValuePairs`](http://package.elm-lang.org/packages/elm-lang/core/latest/Json-Decode#keyValuePairs) helps you turn a JSON object into an Elm list of keys and values.
 
 
 ## Decoding Objects


### PR DESCRIPTION
There are many ways to improve this book. Many of them require structural changes that would present concepts in a better order. These are quite hard to do, especially in a collaborative way if you want the book to come out coherent.

So the kind of PRs that are practical to handle include:

  - [ ] Fixing misspellings
  - [ ] Fixing broken links
  - [ ] Fixing code that is off for some reason, like a missing import or typo

More extreme cases are best reported and organized in a coherent way. From there, it is possible to do a revamp of the book that addresses readers concerns in a coherent way. Ultimately you also have to pick an audience, so it fundamentally cannot work for everyone. By logging who is confused and why, you can do better though!
